### PR TITLE
Add support for Pro XDR Display

### DIFF
--- a/asdcontrol.cpp
+++ b/asdcontrol.cpp
@@ -60,6 +60,7 @@ const int APPLE                           = 0x05ac;
 
 // Supported monitors
 const int STUDIO_DISPLAY_27               = 0x1114;
+const int PRO_XDR_DISPLAY_32              = 0x9243;
 
 // Forward Declarations
 void init_device_database();
@@ -670,6 +671,9 @@ int main ( int argc, char **argv )
 void init_device_database()
 {
     supportedVendors.insert ( VendorDesc ( APPLE, "Apple" ) );
+
+    supportedDevices.insert ( DeviceId ( APPLE, PRO_XDR_DISPLAY_32,
+                                         "Apple Pro XDR Display (2019, 32\")", 400, 60000 ) );
 
     supportedDevices.insert ( DeviceId ( APPLE, STUDIO_DISPLAY_27,
                                          "Apple Studio Display (2022, 27\")", 400, 60000 ) );


### PR DESCRIPTION
Hi! Since asdcontrol actually works with Pro Display XDR, I thought it might be a good idea to add an explicit support (and also closes #1). I've tested it with mine and the brightness control works perfectly.

The display seems to have the brightness value range of 0-65535, so I'm reusing the same 400-60000.