### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,57 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "path": "/nix/store/v0g0bxsd5gw6k0jz2855f8h7l1218925-source",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,21 +1,49 @@
 {
-  outputs = {
-    nixpkgs,
-    flake-utils,
-    ...
-  }: 
-  flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in
+  outputs =
     {
-      packages.default = pkgs.stdenv.mkDerivation {
-        name = "asdcontrol";
-        src = pkgs.lib.cleanSource ./.;
-        installPhase = ''
-          mkdir -p $out/bin
-          mv asdcontrol $out/bin
-        '';
-      };
-    });
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.stdenv.mkDerivation {
+          name = "asdcontrol";
+          src = pkgs.lib.cleanSource ./.;
+          installPhase = ''
+            mkdir -p $out/bin
+            mv asdcontrol $out/bin
+          '';
+        };
+      }
+    )
+    // {
+      modules.asdcontrol =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.asdcontrol;
+        in
+        {
+          options.programs.asdcontrol = {
+            enable = lib.mkEnableOption "Enables asdcontrol (brightness control for Apple Monitors)";
+          };
+          config = lib.mkIf cfg.enable {
+            environment.defaultPackages = [ self.packages.${pkgs.system}.default ];
+            services.udev.extraRules = ''
+              KERNEL=="hiddev*", ATTRS{idVendor}=="05ac", ATTRS{idProduct}=="1114", GROUP="users", OWNER="root", MODE="0660"
+              KERNEL=="hiddev*", ATTRS{idVendor}=="05ac", ATTRS{idProduct}=="9243", GROUP="users", OWNER="root", MODE="0660"
+            ''; # Studio Display (1114), Pro Display XDR (9243)
+          };
+        };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }: 
+  flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages.default = pkgs.stdenv.mkDerivation {
+        name = "asdcontrol";
+        src = pkgs.lib.cleanSource ./.;
+        installPhase = ''
+          mkdir -p $out/bin
+          mv asdcontrol $out/bin
+        '';
+      };
+    });
+}


### PR DESCRIPTION
Feel free to close this one if you strongly feel against nix - I'll keep it in my fork.
For nix(os) users:

This PR enables a couple of things, like running asdcontrol without installing:
``` bash
nix run github:nikosdion/asdcontrol
```

The flake also exposes a nix module that installs asdcontrol and enables udev rules for Studio Display and XDR Display.
``` nix
# in flake.nix
inputs.asdcontrol.url = "github:nikosdion/asdcontrol";

# in configuration.nix or flake.nix in machine section
imports = [
  inputs.asdcontrol.modules.asdcontrol
];

# in configuration.nix
programs.asdcontrol.enable = true;
```